### PR TITLE
pplib dependencies, RTT average

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ AC_CHECK_LIB([resolv], [res_mkquery], [], [
 ])
 AC_CHECK_LIB([idn], [idna_to_ascii_4z])
 AC_CHECK_LIB([idn2], [idn2_to_ascii_4z])
+AC_CHECK_LIB([pcre], [pcre_exec])
 
 # Check for OS specific libraries
 case "$host_os" in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,8 @@
 # along with dnsmeter.  If not, see <http://www.gnu.org/licenses/>.
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
-CLEANFILES = dnsmeter.1
+CLEANFILES = dnsmeter.1 $(srcdir)/pplib/include/ppl7-config.h \
+  $(srcdir)/pplib/release/libppl7.a
 
 SUBDIRS =
 
@@ -43,10 +44,10 @@ pplib/include/ppl7-config.h:
 	cd "$(srcdir)/pplib" && ./configure --disable-oggtest \
 --disable-freetypetest --disable-sdltest --disable-sdlframework \
 --without-jpeg --without-libjpegturbo --without-libpng \
---without-libmicrohttpd --without-libmcrypt-prefix --without-libidn \
---without-libidn2 --without-libtiff --without-libcurl --without-mpg123 \
+--without-libmicrohttpd --without-libmcrypt-prefix \
+--without-libtiff --without-libcurl --without-mpg123 \
 --without-lame --without-ogg --without-libcdio --without-libiconv-prefix \
---without-pcre --without-imlib --without-mysql --without-postgresql \
+--without-imlib --without-mysql --without-postgresql \
 --without-sqlite3 --without-libldn --without-nasm
 
 $(srcdir)/pplib/release/libppl7.a: pplib/include/ppl7-config.h

--- a/src/dns_sender.cpp
+++ b/src/dns_sender.cpp
@@ -177,7 +177,6 @@ ppl7::Array DNSSender::getQueryRates(const ppl7::String& QueryRates)
             for (ppluint64 i = matches[1].toUnsignedInt64(); i <= matches[2].toUnsignedInt64(); i += matches[3].toUnsignedInt64()) {
                 rates.addf("%llu", i);
             }
-
         } else {
             rates.explode(QueryRates, ",");
         }
@@ -543,7 +542,7 @@ void DNSSender::presentResults(const DNSSender::Results& result)
     printf("DNS rtt average: %0.4f ms, "
            "min: %0.4f ms, "
            "max: %0.4f ms\n",
-        result.rtt_total * 1000.0 / (double)ThreadCount,
+        result.rtt_total * 1000.0 / (double)result.counter_received,
         result.rtt_min * 1000.0,
         result.rtt_max * 1000.0);
     printf("DNS truncated: %llu\nDNS RCODES: ", result.truncated);


### PR DESCRIPTION
- Fix pplib dependencies
- `DNSSender::presentResults()`: Fix RTT average calculation