### PR TITLE
Typo, random source port

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ AC_ARG_WITH([extra-cflags], [AS_HELP_STRING([--with-extra-cflags=CFLAGS], [Add e
 ])
 
 # Check --with-extra-ldflags
-AC_ARG_WITH([extra-ldflags], [AS_HELP_STRING([--with-extra-ldflags=CFLAGS], [Add extra LDFLAGS])], [
+AC_ARG_WITH([extra-ldflags], [AS_HELP_STRING([--with-extra-ldflags=LDFLAGS], [Add extra LDFLAGS])], [
   AC_MSG_NOTICE([appending extra LDFLAGS... $withval])
   AS_VAR_APPEND(LDFLAGS, [" $withval"])
 ])

--- a/src/dns_sender_thread.cpp
+++ b/src/dns_sender_thread.cpp
@@ -158,6 +158,8 @@ void DNSSenderThread::sendPacket()
                     pkt.randomSourceIP(spoofing_net_start, spoofing_net_size);
                     pkt.randomSourcePort();
                 }
+            } else {
+                pkt.randomSourcePort();
             }
             pkt.setDnsId(getQueryTimestamp());
             ssize_t n = Socket.send(pkt);


### PR DESCRIPTION
- Fix typo in configure
- `sender`: Fix #28: Randomize source port when only using `-q`